### PR TITLE
WIP: Match the correct number of params for TransportElectrons

### DIFF
--- a/base/inc/AdePT/1/LoopNavigator.h
+++ b/base/inc/AdePT/1/LoopNavigator.h
@@ -11,6 +11,7 @@
 
 #include <CopCore/1/Global.h>
 
+#include "test_header.h"
 #include <VecGeom/base/Global.h>
 #include <VecGeom/base/Vector3D.h>
 #include <VecGeom/navigation/NavStateIndex.h>

--- a/base/inc/AdePT/1/test_header.h
+++ b/base/inc/AdePT/1/test_header.h
@@ -1,0 +1,11 @@
+
+#ifdef __SYCL_DEVICE_ONLY__
+  #define __constant__ 
+  #define VECGEOM_DEVICE_COMPILATION
+  #define VECCORE_CUDA_DEVICE_COMPILATION
+  #pragma message("__SYCL_DEVICE_ONLY__")
+#else
+  #pragma message("NOT __SYCL_DEVICE_ONLY__")
+#endif
+
+

--- a/base/inc/CopCore/1/Global.h
+++ b/base/inc/CopCore/1/Global.h
@@ -9,7 +9,6 @@
 #ifndef COPCORE_1GLOBAL_H_
 #define COPCORE_1GLOBAL_H_
 
-#define DPCT_USM_LEVEL_NONE
 #include <CL/sycl.hpp>
 #include <dpct/dpct.hpp>
 #include <cstdio>

--- a/base/inc/CopCore/1/VariableSizeObj.h
+++ b/base/inc/CopCore/1/VariableSizeObj.h
@@ -215,7 +215,8 @@ public:
     // Make an instance of the class which allocates the node array. To be
     // released using ReleaseInstance.
     size_t needed = SizeOf(nvalues);
-    char *ptr     = new char[needed];
+    char *ptr = (char *)malloc(needed);
+    //char *ptr     = new char[needed];
     if (!ptr) return 0;
     assert((((unsigned long long)ptr) % alignof(Cont)) == 0 && "alignment error");
     Cont *obj                         = new (ptr) Cont(nvalues, params...);
@@ -246,7 +247,8 @@ public:
     // Make a copy of the variable size array and its container.
 
     size_t needed = SizeOf(other.GetVariableData().fN);
-    char *ptr     = new char[needed];
+    //char *ptr     = new char[needed];
+    char *ptr = (char *)malloc(needed);
     if (!ptr) return 0;
     Cont *copy    = new (ptr) Cont(other);
     copy->GetVariableData().fSelfAlloc = true;
@@ -260,7 +262,8 @@ public:
     // a new_size of the content.
 
     size_t needed = SizeOf(new_size);
-    char *ptr     = new char[needed];
+    //char *ptr     = new char[needed];
+    char *ptr = (char *)malloc(needed);
     if (!ptr) return 0;
     Cont *copy    = new (ptr) Cont(new_size, other);
     copy->GetVariableData().fSelfAlloc = true;
@@ -301,7 +304,8 @@ public:
   {
     // Releases the space allocated for the object
     obj->~Cont();
-    if (obj->GetVariableData().fSelfAlloc) delete[](char *) obj;
+    //if (obj->GetVariableData().fSelfAlloc) delete[](char *) obj;
+    if (obj->GetVariableData().fSelfAlloc) free(obj);
   }
 
   // Equivalent of sizeof function (not taking into account padding for alignment)

--- a/examples/Example9.1/electrons.dp.cpp
+++ b/examples/Example9.1/electrons.dp.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2021 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#include <AdePT/1/test_header.h>
 #include <CL/sycl.hpp>
 #include <dpct/dpct.hpp>
 #include "example9.dp.hpp"

--- a/examples/Example9.1/example9.cpp
+++ b/examples/Example9.1/example9.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2021 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#include <AdePT/1/test_header.h>
 #include "example9.h"
 
 #include <AdePT/1/ArgParser.h>
@@ -99,7 +100,14 @@ int main(int argc, char *argv[])
   if (!load) return 3;
 #endif
 
+
+#ifdef __SYCL_DEVICE_ONLY__
   const vecgeom::VPlacedVolume *world = vecgeom::GeoManager::Instance().GetWorld();
+#else
+  const vecgeom::cxx::VPlacedVolume *world = vecgeom::GeoManager::Instance().GetWorld();
+#endif
+
+  //const vecgeom::VPlacedVolume *world = vecgeom::GeoManager::Instance().GetWorld();
   if (!world) return 4;
 
   example9(world, particles, energy);

--- a/examples/Example9.1/example9.cu
+++ b/examples/Example9.1/example9.cu
@@ -112,6 +112,18 @@ struct ParticleType {
 
     NumParticleTypes,
   };
+
+  // default constructor
+  ParticleType() {}
+
+  // Copy constructor
+  ParticleType(const ParticleType &particleType) {
+    tracks = particleType.tracks;
+    slotManager = particleType.slotManager;
+    queues = particleType.queues;
+    stream = particleType.stream;
+    event = particleType.event;
+  }
 };
 
 // A bundle of queues for the three particle types.

--- a/examples/Example9.1/example9.cu
+++ b/examples/Example9.1/example9.cu
@@ -112,18 +112,6 @@ struct ParticleType {
 
     NumParticleTypes,
   };
-
-  // default constructor
-  ParticleType() {}
-
-  // Copy constructor
-  ParticleType(const ParticleType &particleType) {
-    tracks = particleType.tracks;
-    slotManager = particleType.slotManager;
-    queues = particleType.queues;
-    stream = particleType.stream;
-    event = particleType.event;
-  }
 };
 
 // A bundle of queues for the three particle types.

--- a/examples/Example9.1/example9.dp.cpp
+++ b/examples/Example9.1/example9.dp.cpp
@@ -143,6 +143,20 @@ struct ParticleType {
 
     NumParticleTypes,
   };
+
+
+  // default constructor
+  ParticleType() {}
+
+  // Copy constructor
+  ParticleType(const ParticleType &particleType) {
+    tracks = particleType.tracks;
+    slotManager = particleType.slotManager;
+    queues = particleType.queues;
+    stream = particleType.stream;
+    event = particleType.event;
+    event_ct1 = particleType.event_ct1;
+  }
 };
 
 // A bundle of queues for the three particle types.

--- a/examples/Example9.1/example9.dp.cpp
+++ b/examples/Example9.1/example9.dp.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2021 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+
+#include <AdePT/1/test_header.h>
 #include <CL/sycl.hpp>
 #include <dpct/dpct.hpp>
 #include "example9.h"
@@ -160,8 +162,7 @@ void InitParticleQueues(ParticleQueues queues, size_t Capacity)
 
 // Kernel function to initialize a set of primary particles.
 void InitPrimaries(ParticleGenerator generator, int particles, double energy,
-		   const vecgeom::VPlacedVolume *world,
-                              sycl::nd_item<3> item_ct1)
+		   const vecgeom::VPlacedVolume *world, sycl::nd_item<3> item_ct1)
 {
   for (int i = item_ct1.get_group(2) * item_ct1.get_local_range().get(2) +
                item_ct1.get_local_id(2);

--- a/examples/Example9.1/example9.dp.hpp
+++ b/examples/Example9.1/example9.dp.hpp
@@ -56,6 +56,22 @@ struct Track {
     this->currentState = parent.currentState;
     this->nextState    = parent.nextState;
   }
+
+  // default constructor
+  Track() {}
+
+  // Copy constructor
+  Track(const Track &track) {
+    rngState = track.rngState;
+    energy = track.energy;
+    for (int i = 0; i < 3; i++) {
+      numIALeft[i] = track.numIALeft[i];
+    }
+    pos = track.pos;
+    dir = track.dir;
+    currentState = track.currentState;
+    nextState = track.nextState;
+  }
 };
 
 class RanluxppDoubleEngine : public G4HepEmRandomEngine {

--- a/examples/Example9.1/example9.dp.hpp
+++ b/examples/Example9.1/example9.dp.hpp
@@ -56,22 +56,6 @@ struct Track {
     this->currentState = parent.currentState;
     this->nextState    = parent.nextState;
   }
-
-  // default constructor
-  Track() {}
-
-  // Copy constructor
-  Track(const Track &track) {
-    rngState = track.rngState;
-    energy = track.energy;
-    for (int i = 0; i < 3; i++) {
-      numIALeft[i] = track.numIALeft[i];
-    }
-    pos = track.pos;
-    dir = track.dir;
-    currentState = track.currentState;
-    nextState = track.nextState;
-  }
 };
 
 class RanluxppDoubleEngine : public G4HepEmRandomEngine {
@@ -151,12 +135,7 @@ void RelocateToNextVolume(Track *allTracks, const adept::MParray *relocateQueue)
 template <bool IsElectron>
 void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
                                    adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring,
-                                   sycl::nd_item<3> item_ct1
-                                  //  ,
-                                  //  struct G4HepEmElectronManager *electronManager,
-                                  //  struct G4HepEmParameters g4HepEmPars,
-                                  //  struct G4HepEmData g4HepEmData
-                                   );
+                                   sycl::nd_item<3> item_ct1);
 extern template void TransportElectrons</*IsElectron*/true>(
     Track *electrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
     adept::MParray *relocateQueue, GlobalScoring *scoring, sycl::nd_item<3> item_ct1);

--- a/examples/Example9.1/example9.dp.hpp
+++ b/examples/Example9.1/example9.dp.hpp
@@ -133,17 +133,17 @@ struct Secondaries {
 void RelocateToNextVolume(Track *allTracks, const adept::MParray *relocateQueue);
 
 template <bool IsElectron>
-void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
+SYCL_EXTERNAL void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
                                    adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring,
                                    sycl::nd_item<3> item_ct1);
 extern template void TransportElectrons</*IsElectron*/true>(
     Track *electrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
     adept::MParray *relocateQueue, GlobalScoring *scoring, sycl::nd_item<3> item_ct1);
-extern template void TransportElectrons</*IsElectron*/false>(
+extern  template void TransportElectrons</*IsElectron*/false>(
     Track *electrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
     adept::MParray *relocateQueue, GlobalScoring *scoring, sycl::nd_item<3> item_ct1);
 
-void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
+SYCL_EXTERNAL void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
 		     adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring, sycl::nd_item<3> item_ct1);
 
 // Constant data structures from G4HepEm accessed by the kernels.

--- a/examples/Example9.1/example9.dp.hpp
+++ b/examples/Example9.1/example9.dp.hpp
@@ -135,10 +135,12 @@ void RelocateToNextVolume(Track *allTracks, const adept::MParray *relocateQueue)
 template <bool IsElectron>
 void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
                                    adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring,
-                                   sycl::nd_item<3> item_ct1,
-                                   struct G4HepEmElectronManager *electronManager,
-                                   struct G4HepEmParameters g4HepEmPars,
-                                   struct G4HepEmData g4HepEmData);
+                                   sycl::nd_item<3> item_ct1
+                                  //  ,
+                                  //  struct G4HepEmElectronManager *electronManager,
+                                  //  struct G4HepEmParameters g4HepEmPars,
+                                  //  struct G4HepEmData g4HepEmData
+                                   );
 extern template void TransportElectrons</*IsElectron*/true>(
     Track *electrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
     adept::MParray *relocateQueue, GlobalScoring *scoring, sycl::nd_item<3> item_ct1);

--- a/examples/Example9.1/gammas.dp.cpp
+++ b/examples/Example9.1/gammas.dp.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2021 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#include <AdePT/1/test_header.h>
 #include <CL/sycl.hpp>
 #include <dpct/dpct.hpp>
 #include "example9.dp.hpp"


### PR DESCRIPTION
 Solving this error: 
`explicit instantiation of 'TransportElectrons' does not refer to a function template, variable template, member function, member class, or static data member`


Currently working on this error
```
/home/dadosaru/OneAPI-Playground/examples/Example9.1/example9.dp.cpp:412:40: error: kernel parameter has non-trivially copy constructible class/struct type 'ParticleType'
              TransportElectrons<true>(electrons.tracks,
```